### PR TITLE
Switch to use cl-copy-list

### DIFF
--- a/notes-list.el
+++ b/notes-list.el
@@ -48,6 +48,7 @@
 (require 'svg-lib)
 (require 'svg-tag-mode)
 (require 'nano-theme)
+(require 'cl-lib)
 
 (defgroup notes-list nil
   "Note list"
@@ -109,7 +110,7 @@
             (img-height (* (+ (/ height dy) 1) dy))
             (char-width (+ (/ img-height dx) 1))
             (img-width (* char-width dx))
-            (thumbnail (cons (car image) (copy-list (cdr image)))))
+            (thumbnail (cons (car image) (cl-copy-list (cdr image)))))
       (plist-put (cdr thumbnail) :height img-height)
       (plist-put (cdr thumbnail) :width nil)
       (plist-put (cdr thumbnail) :ascent 80)


### PR DESCRIPTION
I was getting an error due to `copy-list` not being defined. As the package `cl` is deprecated I've switched to use `cl-copy-list` from `cl-lib`.