### PR TITLE
Use exact pixel width of line contents to determine filler width

### DIFF
--- a/notes-list.el
+++ b/notes-list.el
@@ -276,24 +276,18 @@ truncated."
       (put-text-property start (point)
                          'filename filename))))
 
-(defsubst notes-list--guaranteed-posn-at-point ()
-  (let ((posn (posn-at-point)))
-    (if posn
-        posn
-      ;; Force redisplay to make sure that posn-at-point works (and does not
-      ;; return nil)
-      (redisplay)
-      (posn-at-point))))
-
 (defun notes-list--pixel-width-between-points (point1 point2)
   "Calculate pixel width of buffer contents between POINT1 and POINT2."
+  ;; Force redisplay to make sure that posn-at-point is accurate (and does not
+  ;; return nil)
+  (redisplay)
   (save-excursion
     (let* ((posn1 (progn
                    (goto-char point1)
-                   (notes-list--guaranteed-posn-at-point)))
+                   (posn-at-point)))
            (posn2 (progn
                     (goto-char point2)
-                    (notes-list--guaranteed-posn-at-point)))
+                    (posn-at-point)))
            (ydelta (- (cdaddr posn2)
                       (cdaddr posn1)))
            (window-width (window-width (selected-window) t))
@@ -450,7 +444,6 @@ need to be defined at top level as keywords."
 
 (defun notes-list--resize-hook (frame)
   "Refresh notes list if necessary"
-
   (when-let* ((window (get-buffer-window (notes-list-buffer))))
     (let ((window-width (window-width window)))
       (unless (eq window-width notes-list--buffer-width)


### PR DESCRIPTION
This fixes some flakiness in determining filler width based on the tag text length by using the actual display width in pixels of both the tags and the summary to come to an appropriate width.

## Rationale
It could be my window manager situation (xwayland ubuntu 23.04 and emacs is running from within a docker container), but I experienced some flakiness in the alignment of the tags in each note line. At some window sizes, the filler space did not entirely account for the width of the tags displayed. Below are some pictures to explain the situation, taken of a fresh emacs (no custom config) with just notes-list and its other dependencies installed. It seems to me that the problem was in the display width of the tag svgs ever so slightly differing from the width of the text displayed in them, so I resorted to calculating their real displayed pixel width and setting the filler width in absolute pixels.

That being said.. it works on my machine&trade; , I hope it works on yours too :)

### Before changes
![Screenshot from 2023-06-16 16-36-35](https://github.com/rougier/notes-list/assets/25674281/c1751d16-2055-44ad-a2b6-f823356e971c)

### After Changes
![Screenshot from 2023-06-17 09-04-01](https://github.com/rougier/notes-list/assets/25674281/ce029d54-40f4-4801-96fe-7cc1938bfc41)
