### PR TITLE
Define faces for stripes and highlight + remove nano-theme dependency

### DIFF
--- a/notes-list.el
+++ b/notes-list.el
@@ -47,7 +47,6 @@
 (require 'stripes)
 (require 'svg-lib)
 (require 'svg-tag-mode)
-(require 'nano-theme)
 (require 'cl-lib)
 
 (defgroup notes-list nil
@@ -101,7 +100,7 @@
   :group 'notes-list)
 
 (defface notes-list-face-tags
-  '((t (:inherit nano-faded)))
+  '((t (:inherit nano-salient)))
   "Face for notes tags"
   :group 'notes-list)
 
@@ -114,6 +113,14 @@
   '((t (:inherit nano-faded)))
   "Face for notes time"
   :group 'notes-list)
+
+(defface notes-list-face-stripe
+  `((t (:inherit highlight)))
+  "Face to use for alternating note style in list.")
+
+(defface notes-list-face-highlight
+  `((t (:inherit nano-subtle)))
+  "Face to use for selected note style in list.")
 
 (defvar notes-list--icons nil
   "Icons cache")
@@ -186,7 +193,7 @@ two parts (top . bottom)"
 (defun notes-list--make-tag (tag)
 
   (let ((svg-tag (if (string-equal tag "INBOX")
-                     (svg-tag-make tag :face 'nano-salient :inverse t)
+                     (svg-tag-make tag :face 'notes-list-face-tags :inverse t)
                    (svg-tag-make tag :face 'default))))
   (propertize (concat tag " ") 'display svg-tag)))
 
@@ -473,7 +480,6 @@ need to be defined at top level as keywords."
 
   (get-buffer-create "*notes-list*"))
 
-
 (define-minor-mode notes-list-mode
   "A minor mode for browsing note list"
 
@@ -498,8 +504,8 @@ need to be defined at top level as keywords."
     (stripes-mode t)
     (setq hl-line-overlay-priority 100)
     (hl-line-mode t)
-    (face-remap-set-base 'stripes :inherit 'highlight)
-    (face-remap-add-relative 'hl-line :inherit 'nano-subtle)
+    (face-remap-set-base 'stripes :inherit 'notes-list-face-stripe)
+    (face-remap-add-relative 'hl-line :inherit 'notes-list-face-highlight)
     (setq-local cursor-type nil)
     (read-only-mode t)
     (add-hook 'window-size-change-functions #'notes-list--resize-hook)))


### PR DESCRIPTION
This allows people to use the package without having nano-theme installed, and allows theme-makers to define custom faces for it.