### PR TITLE
Fix org file extension

### DIFF
--- a/notes-list.el
+++ b/notes-list.el
@@ -351,7 +351,7 @@ need to be defined at top level as keywords."
 (defun notes-list-collect-org-notes ()
   (let ((notes nil))
     (dolist (directory notes-list-directories)
-      (dolist (filename (directory-files directory t ".*\\.org"))
+      (dolist (filename (directory-files directory t ".*\\.org$"))
         (when (notes-list-note-p filename)
           (let ((note (notes-list-parse-org-note filename)))
             (setq notes (add-to-list 'notes note))))))


### PR DESCRIPTION
Fix selecting files ending in .org. In the master branch, the notes-list-collect-org-notes function doesn't exclude org archive files, causing an error. This tiny edit fixes that. 